### PR TITLE
Improve performance and add ZMQ based script

### DIFF
--- a/calculate_average.rb
+++ b/calculate_average.rb
@@ -1,23 +1,20 @@
 # https://stackoverflow.com/questions/16159370/ruby-hash-default-value-behavior
 
-measurements_file = File.open('measurements.txt', 'r')
-
 stations = Hash.new {|hsh, key| hsh[key] = [] }
 
-measurements_file.each do |line|
+STDIN.each_line do |line|
   location, temperature = line.chomp.split(';')
 
   stations[location] << temperature.to_f
 end
 
-stations.each do |station, measurements|
-  puts "#{station} - min: #{measurements.first}, max: #{measurements.first}, avg: #{measurements.first}" if measurements.size == 1 && next
+stations_aggregated = stations.transform_values do |measurements|
+  min, max = measurements.minmax
+  avg = measurements.sum / measurements.size
 
-  measurements.sort!
+  [min, avg, max]
+end
 
-  min = measurements.first
-  max = measurements.last
-  avg = measurements.sum(0.0) / measurements.size
-
-  puts "#{station} - min: #{min}, max: #{max}, avg: #{avg}"
+stations_aggregated.sort.map do |station, (min, avg, max)|
+  puts format('%s=%.1f/%.1f/%.1f', station, min, avg, max)
 end

--- a/calculate_average_zmq.rb
+++ b/calculate_average_zmq.rb
@@ -1,0 +1,123 @@
+#!/usr/bin/env ruby --yjit
+# Run with: time pv --rate --average-rate --progress measurements.txt | ./calculate_average_zmq.rb > agg.txt
+
+require 'English'
+require 'bundler/inline'
+
+gemfile do
+  gem 'timeout'
+  gem 'async'
+  gem 'cztop'
+end
+
+WORKERS         = 16
+CHUNK_SIZE      = 2**20 # 1 MiB
+MAP_ENDPOINT    = "ipc:///tmp/1brc.map.#$PROCESS_ID"
+REDUCE_ENDPOINT = "ipc:///tmp/1brc.reduce.#$PROCESS_ID"
+
+City = Struct.new(:min, :tot, :max, :n)
+
+def city_hash
+  Hash.new do |h,k|
+    h[k] = City.new Float::INFINITY, 0, -Float::INFINITY, 0
+  end
+end
+
+warn "main: #$PROCESS_ID"
+worker_pids = WORKERS.times.map do |worker_id|
+  fork do
+    warn "worker #{worker_id}: #$PROCESS_ID"
+    Process.setproctitle("#$0: worker #%d" % worker_id)
+    pull_socket = CZTop::Socket::PULL.new
+    push_socket = CZTop::Socket::PUSH.new
+
+    pull_socket.connect MAP_ENDPOINT
+    push_socket.connect REDUCE_ENDPOINT
+
+    while true
+      chunk  = pull_socket.receive.to_a.first
+      cities = city_hash
+
+      chunk.each_line do |line|
+        name, val = line.split(";", 2)
+        city      = cities[name]
+        city.n   += 1
+        val       = Float val
+        city.min  = val if val < city.min
+        city.max  = val if val > city.max
+        city.tot += val
+      end
+
+      cities.default_proc = nil # make dumpable
+      push_socket << Marshal.dump(cities)
+    end
+  end
+end
+
+
+at_exit do
+  Timeout.timeout 1 do
+    warn "main: terminating workers: #{worker_pids}"
+    Process.kill(:TERM, *worker_pids)
+    Process.waitall
+  end
+rescue Interrupt, Timeout::Error
+  worker_pids.each do |pid|
+    Process.kill(:KILL, pid)
+  rescue SystemCallError
+    # already dead
+  else
+    warn "main: killed worker #{pid}"
+  end
+end
+
+
+Async do |task|
+  all_chunks_sent = false
+  nchunks         = 0
+
+  task.async annotation: 'map' do
+    push_socket = CZTop::Socket::PUSH.new
+    push_socket.bind MAP_ENDPOINT
+
+    chunk = ''
+
+    until STDIN.eof?
+      STDIN.read CHUNK_SIZE, chunk # ensures UTF-8
+      # ensure we're on a line boundary
+      chunk += STDIN.readline unless STDIN.eof?
+
+      push_socket << chunk
+      nchunks += 1
+    end
+
+    all_chunks_sent = true
+    warn "main: all chunks sent to workers"
+  end
+
+  task.async annotation: 'reduce' do
+    results     = city_hash
+    pull_socket = CZTop::Socket::PULL.new
+    pull_socket.bind REDUCE_ENDPOINT
+
+    until all_chunks_sent && nchunks.zero?
+      cities = Marshal.load pull_socket.receive.to_a.first
+
+      results.merge! cities do |name, left, right|
+        left.min  = right.min if right.min < left.min
+        left.max  = right.max if right.max > left.max
+        left.tot += right.tot
+        left.n   += right.n
+        left
+      end
+
+      nchunks -= 1
+    end
+
+    warn "main: sorting and printing ..."
+    results.sort_by(&:first).each do |name, city|
+      puts format("%s=%.1f/%.1f/%.1f", name, city.min, city.tot / city.n, city.max)
+    end
+  end
+end
+

--- a/create_measurements.rb
+++ b/create_measurements.rb
@@ -10,10 +10,12 @@ rescue
   abort "Usage: #$0 <INT>"
 end
 
-measurements_file = File.open(MEASUREMENTS_FILE_NAME, 'w')
 
-iterations.times do
-  stations_size = Stations.ary.size
-  station = Stations.ary[SecureRandom.random_number(stations_size)]
-  measurements_file.puts "#{station.location};#{station.measurement}"
+stations = Stations.ary
+
+File.open(MEASUREMENTS_FILE_NAME, 'w') do |f|
+  iterations.times do
+    station = stations.sample
+    f.puts "#{station.location};#{station.measurement}"
+  end
 end

--- a/create_measurements.rb
+++ b/create_measurements.rb
@@ -4,7 +4,11 @@ require_relative './stations/stations'
 
 MEASUREMENTS_FILE_NAME = 'measurements.txt'
 
-iterations = ARGV.first.to_i
+begin
+  iterations = Integer ARGV.first
+rescue
+  abort "Usage: #$0 <INT>"
+end
 
 measurements_file = File.open(MEASUREMENTS_FILE_NAME, 'w')
 

--- a/stations/weather_station.rb
+++ b/stations/weather_station.rb
@@ -1,5 +1,3 @@
-require 'securerandom'
-
 class WeatherStation
   attr_reader :location, :mean_temperature
 
@@ -12,7 +10,7 @@ class WeatherStation
 
   # random gaussian
   def measurement
-    (SecureRandom.random_number * STANDARD_DEVIATION + mean_temperature).round(1)
+    (Random.rand * STANDARD_DEVIATION + mean_temperature).round(1)
   end
 end
 

--- a/time_measurements_creation
+++ b/time_measurements_creation
@@ -12,13 +12,13 @@ RVERSION=$(ruby -v | cut -d ' ' -f 2)
 
 for iteration in {1..5}
 do
-  /usr/bin/time -o time_"$RVERSION"_$iteration.txt ruby $measurements_script $measurements
+  /usr/bin/time -o time_"$RVERSION"_$iteration.txt ruby $measurements_script < $measurements > /dev/null
 done
 
 ruby -v --jit
 for iteration in {1..5}
 do
-  /usr/bin/time -o "time_"$RVERSION"jit_$iteration.txt" ruby --jit $measurements_script $measurements
+  /usr/bin/time -o "time_"$RVERSION"jit_$iteration.txt" ruby --jit $measurements_script < $measurements > /dev/null
 done
 
 # Ruby 3.3.0
@@ -28,5 +28,5 @@ ruby -v
 RVERSION=$(ruby -v | cut -d ' ' -f 2)
 for iteration in {1..5}
 do
-  /usr/bin/time -o "time_"$RVERSION"_$iteration.txt" ruby $measurements_script $measurements
+  /usr/bin/time -o "time_"$RVERSION"_$iteration.txt" ruby $measurements_script < $measurements > /dev/null
 done


### PR DESCRIPTION
This mostly avoids calling `Stions.ary` during every iteration, which would create the same Array over and over again. Instead, the Array is cached. It also makes sure the file is closed before the script exists by passing a block to `File.open`. And instead of `SecureRandom`, it uses `Random`. And to get a random element from the Array, it uses `Array#sample`.

Increased throughput from 50KiB/s to 12MiB/s (13MiB/s with JIT) on my tiny VM, measured with `pv` (and writing to STDOUT instead of directly to a file).

The added script aggregates the measurements using forked workers. Communication happens over ZMQ sockets.